### PR TITLE
Add npm bugs metadata for @mokei/context-client

### DIFF
--- a/packages/context-client/package.json
+++ b/packages/context-client/package.json
@@ -18,6 +18,9 @@
     "url": "https://github.com/TairuFramework/mokei",
     "directory": "packages/context-client"
   },
+  "bugs": {
+    "url": "https://github.com/TairuFramework/mokei/issues"
+  },
   "type": "module",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
## Summary

- add `bugs.url` metadata to `@mokei/context-client`

This lets npm users and tooling navigate from the package metadata to the GitHub issue tracker. The change is metadata-only and does not affect runtime behavior.

## Validation

- `node -e "const p=require('./packages/context-client/package.json'); if(p.bugs?.url!=='https://github.com/TairuFramework/mokei/issues') throw new Error('bugs metadata mismatch'); console.log('metadata smoke ok')"`
- `npm pack --dry-run --ignore-scripts ./packages/context-client`
- `git diff --check`